### PR TITLE
コレクションのデータ構造明らかにする

### DIFF
--- a/src/worker.js
+++ b/src/worker.js
@@ -1,8 +1,56 @@
-const worker = require('workerpool').worker
+const { worker } = require('workerpool')
 const { VM } = require('vm2')
 const { inspect } = require('util')
 
-const run = code =>
-  inspect(new VM().run(code), { depth: null, maxArrayLength: null })
+const run = async code => {
+  const vm = new VM({
+    sandbox: {
+      Set, Map, Date, WeakSet, WeakMap,
+      Buffer, ArrayBuffer, SharedArrayBuffer,
+      Int8Array, Uint8Array, Uint8ClampedArray,
+      Int16Array, Uint16Array,
+      Int32Array, Uint32Array,
+      Float32Array, Float64Array,
+      BigInt64Array, BigUint64Array
+    }
+  })
+  const result = await vm.run(code)
+  const VMRegExp = vm.run("RegExp")
+  VMRegExpProtoToString = VMRegExp.prototype.toString
+  Object.defineProperty(VMRegExp.prototype, inspect.custom, { 
+    value(_, options) {
+      try {
+        return VMRegExpProtoToString.call(this)
+      } catch {
+        return inspect(
+          Object.defineProperty(
+            this, inspect.custom,
+            { value: void 0 }
+          ), 
+          options
+        )
+      }
+    }
+  })
+  for (const type of ["Number", "String", "Boolean", "Symbol", "BigInt"]) {
+    const ctor = vm.run(type), toPrimitive = ctor.prototype.valueOf
+    Object.defineProperty(ctor.prototype, inspect.custom, {
+      value(_, options) {
+        try {
+          return `[${type}: ${inspect(toPrimitive.call(this))}]`
+        } catch {
+          return inspect(
+            Object.defineProperty(
+              this, inspect.custom,
+              { value: void 0 }
+            ), 
+            options
+          )
+        }
+      }
+    })
+  }
+  return inspect(result, { depth: null, maxArrayLength: null })
+}
 
 worker({ run })

--- a/src/worker.js
+++ b/src/worker.js
@@ -15,7 +15,7 @@ const run = async code => {
     }
   })
   const result = await vm.run(code)
-  const VMRegExp = vm.run("RegExp")
+  const VMRegExp = vm.run("RegExp"),
   VMRegExpProtoToString = VMRegExp.prototype.toString
   Object.defineProperty(VMRegExp.prototype, inspect.custom, { 
     value(_, options) {

--- a/src/worker.js
+++ b/src/worker.js
@@ -5,49 +5,56 @@ const { inspect } = require('util')
 const run = async code => {
   const vm = new VM({
     sandbox: {
-      Set, Map, Date, WeakSet, WeakMap,
-      Buffer, ArrayBuffer, SharedArrayBuffer,
-      Int8Array, Uint8Array, Uint8ClampedArray,
-      Int16Array, Uint16Array,
-      Int32Array, Uint32Array,
-      Float32Array, Float64Array,
-      BigInt64Array, BigUint64Array
-    }
+      Set,
+      Map,
+      Date,
+      WeakSet,
+      WeakMap,
+      Buffer,
+      ArrayBuffer,
+      SharedArrayBuffer,
+      Int8Array,
+      Uint8Array,
+      Uint8ClampedArray,
+      Int16Array,
+      Uint16Array,
+      Int32Array,
+      Uint32Array,
+      Float32Array,
+      Float64Array,
+      BigInt64Array,
+      BigUint64Array,
+    },
   })
   const result = await vm.run(code)
-  const VMRegExp = vm.run("RegExp"),
-  VMRegExpProtoToString = VMRegExp.prototype.toString
-  Object.defineProperty(VMRegExp.prototype, inspect.custom, { 
+  const VMRegExp = vm.run('RegExp'),
+    VMRegExpProtoToString = VMRegExp.prototype.toString
+  Object.defineProperty(VMRegExp.prototype, inspect.custom, {
     value(_, options) {
       try {
         return VMRegExpProtoToString.call(this)
       } catch {
         return inspect(
-          Object.defineProperty(
-            this, inspect.custom,
-            { value: void 0 }
-          ), 
+          Object.defineProperty(this, inspect.custom, { value: void 0 }),
           options
         )
       }
-    }
+    },
   })
-  for (const type of ["Number", "String", "Boolean", "Symbol", "BigInt"]) {
-    const ctor = vm.run(type), toPrimitive = ctor.prototype.valueOf
+  for (const type of ['Number', 'String', 'Boolean', 'Symbol', 'BigInt']) {
+    const ctor = vm.run(type),
+      toPrimitive = ctor.prototype.valueOf
     Object.defineProperty(ctor.prototype, inspect.custom, {
       value(_, options) {
         try {
           return `[${type}: ${inspect(toPrimitive.call(this))}]`
         } catch {
           return inspect(
-            Object.defineProperty(
-              this, inspect.custom,
-              { value: void 0 }
-            ), 
+            Object.defineProperty(this, inspect.custom, { value: void 0 }),
             options
           )
         }
-      }
+      },
     })
   }
   return inspect(result, { depth: null, maxArrayLength: null })

--- a/src/worker.js
+++ b/src/worker.js
@@ -38,7 +38,7 @@ const run = async code => {
     const { prototype } = vm.run(type)
     return [type, prototype, prototype.valueOf]
   })
-  
+
   const result = vm.run(code)
 
   Object.defineProperty(vmRegExpPrototype, inspect.custom, {

--- a/src/worker.js
+++ b/src/worker.js
@@ -39,7 +39,7 @@ const run = async code => {
     return [type, prototype, prototype.valueOf]
   })
   
-  let result = vm.run(code)
+  const result = vm.run(code)
 
   Object.defineProperty(vmRegExpPrototype, inspect.custom, {
     value(_, options) {

--- a/src/worker.js
+++ b/src/worker.js
@@ -38,12 +38,8 @@ const run = async code => {
     const { prototype } = vm.run(type)
     return [type, prototype, prototype.valueOf]
   })
-  const promiseProtoThen = vm.run('Promise').prototype.then
-
+  
   let result = vm.run(code)
-  try {
-    result = (await promiseProtoThen.call(result, a => [a]))[0]
-  } catch {}
 
   Object.defineProperty(vmRegExpPrototype, inspect.custom, {
     value(_, options) {


### PR DESCRIPTION
vm2.VMから返却されたSet, Map, Date, RegExp, WeakSet, WeakMap, ArrayBuffer, TypedArray, BoxedPrimitiveなどをutil.inspectすると、情報が抜け落ちる問題の修正