### PR TITLE
Support TypeScript

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5,10 +5,12 @@
   "requires": true,
   "packages": {
     "": {
+      "name": "vm2-discordjs",
       "version": "1.3.0",
       "license": "MIT",
       "dependencies": {
         "discord.js": "^13.6.0",
+        "typescript": "^4.5.5",
         "vm2": "^3.9.8",
         "workerpool": "^6.2.0"
       },
@@ -248,6 +250,18 @@
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
       "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
     },
+    "node_modules/typescript": {
+      "version": "4.5.5",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.5.5.tgz",
+      "integrity": "sha512-TCTIul70LyWe6IJWT8QSYeA54WQe8EjQFU4wY52Fasj5UKx88LNYKCgBEHcOMOrFF1rKGbD8v/xcNWVUq9SymA==",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=4.2.0"
+      }
+    },
     "node_modules/vm2": {
       "version": "3.9.8",
       "resolved": "https://registry.npmjs.org/vm2/-/vm2-3.9.8.tgz",
@@ -473,6 +487,11 @@
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
       "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
+    },
+    "typescript": {
+      "version": "4.5.5",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.5.5.tgz",
+      "integrity": "sha512-TCTIul70LyWe6IJWT8QSYeA54WQe8EjQFU4wY52Fasj5UKx88LNYKCgBEHcOMOrFF1rKGbD8v/xcNWVUq9SymA=="
     },
     "vm2": {
       "version": "3.9.8",

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
   "homepage": "https://github.com/InkoHX/vm2-discordjs#readme",
   "dependencies": {
     "discord.js": "^13.6.0",
+    "typescript": "^4.5.5",
     "vm2": "^3.9.8",
     "workerpool": "^6.2.0"
   },


### PR DESCRIPTION
コードブロックを \`\`\`ts もしくは \`\`\`typescript で囲った場合、javascriptのコードにトランスパイルをしてから出力結果を表示するように変更しました